### PR TITLE
Enable position independent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(everest-sqlite VERSION 0.1.2
+project(everest-sqlite VERSION 0.1.3
         DESCRIPTION "SQLite wrapper for EVerest"
         LANGUAGES CXX C
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,11 @@ target_include_directories(everest_sqlite
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+set_target_properties(everest_sqlite
+    PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+)
+
 #############
 # Logging configuration
 #############


### PR DESCRIPTION
## Describe your changes
Noticed during yocto builds for arm32 that there's a QA issue raised `libframework.so.0.22.1 has relocations in .text [textrel]` which can be traced back to everest-sqlite (and everest-framework) not being built with position independent code turned on. This can also prevent EVerest from starting with a `error while loading shared libraries libframework.so: unexpected reloc type 0x03` error

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
